### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,4 +34,4 @@ spring:
   datasource:
     url: ${CLEARDB_DATABASE_URL}
   jpa.hibernate.ddl-auto: create
-  sql.init.mode: always
+  sql.init.mode: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,4 +34,4 @@ spring:
   datasource:
     url: ${CLEARDB_DATABASE_URL}
   jpa.hibernate.ddl-auto: create
-  sql.init.mode: never
+  sql.init.mode: always

--- a/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisplayName("JPA 연결 테스트")
 @Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {


### PR DESCRIPTION
조사해본 결과, cleardb 의 기본 mysql 버전이 5.6으로 너무 낮기 때문에 문제가 발생한 것으로 확인함 (5.6 버전에서는 article_comment.content 인덱스 사이즈가 너무 큼)
대안으로 jawsdb 를 찾아냄. 기본 mysql 버전이 8.0.
이를 이용해 환경변수를 다시 작업함

This fixes #57

https://devcenter.heroku.com/articles/jawsdb#provisioning-with-custom-options
https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup