### PR TITLE
[고도화] MySQL -> PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,10 +9,9 @@ logging:
 
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/board
+    url: jdbc:postgresql://localhost:5432/board
     username: hyeonggyun
-    password: qwer!@#
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    password: 1234
   jpa:
     open-in-view: false
     defer-datasource-initialization: true


### PR DESCRIPTION
JPA의 이점을 활용하여, 간단하게 프로젝트 DB를 MySQL -> PostgreSQL로 전환 성공.

This closes #68 